### PR TITLE
Fix/import newest version of refseq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea/
+build/
+TransVar.egg-info/
+*.so

--- a/transvar/localdb.py
+++ b/transvar/localdb.py
@@ -832,7 +832,7 @@ class RefSeqDB(TransVarDB):
                 t.strand = fields[6]
                 t.beg = int(fields[3])
                 t.end = int(fields[4])
-                t.name = info['Name'] if 'Name' in info else info['product']
+                t.name = info.get('Name') or info.get('product') or info.get('ID')
                 m = p_trxn_version.match(t.name)
                 if m:
                     t.name = m.group(1)


### PR DESCRIPTION
indexing the newesst version of refseq throws an error due to some entries that lack both a 'Name' and 'product' key.  
`transvar index --refseq hg38.refseq.gff.gz`

This uses the 'ID' field to set the t.name variable in those cases to fix the issue.